### PR TITLE
Fix ExpenseForm typo

### DIFF
--- a/src/components/ExpenseForm.tsx
+++ b/src/components/ExpenseForm.tsx
@@ -69,7 +69,7 @@ const ExpenseForm: React.FC<ExpenseFormProps> = ({
       setTitle(expenseToEdit.title || "");
       setAmount(expenseToEdit.amount.toString() || "");
 
-      wconst category = uniqueCategories.find(
+      const category = uniqueCategories.find(
         (c) => c.name === expenseToEdit.category
       );
       if (category) {


### PR DESCRIPTION
## Summary
- fix a typo in `ExpenseForm.tsx` to correctly declare `category`

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_68442b8b31248320878a43e8a0ddac60